### PR TITLE
Changed simple value's color picker to support PI Coresight 2016 R2

### DIFF
--- a/tutorials/simplevalue/README.md
+++ b/tutorials/simplevalue/README.md
@@ -194,17 +194,22 @@ In this section, you will be creating a simple value symbol, much like the curre
     };
     ```
 
-1. Now that we have it defined in the implementation, we need to create the configuration HTML file. Create a file named `sym-simplevalue-config.html` in the same directory as the implementation and presentation files. The naming convention here is sym-SYMBOL_TYPE_NAME-config.html. This is the default name that the symbol framework will look for if the configuration template is not specified in the symbol definition. Like the presentation layer, the configuration layer is basic HTML. In the example below, we define two sections, Text Color and Background Color, and add a color picker custom control, `format-color-picker`, under each section. `format-color-picker` is an AngularJS [directive](https://docs.angularjs.org/guide/directive) to add the ability to use the PI Coresight color picker to a custom symbol. `format-color-picker` has two custom attributes that are used to link it back to the underlying symbol, `property` and `config`. `property` points to a property on the passed in config object. `config` is the config object of the symbol.
+1. Now that we have it defined in the implementation, we need to create the configuration HTML file. Create a file named `sym-simplevalue-config.html` in the same directory as the implementation and presentation files. The naming convention here is sym-SYMBOL_TYPE_NAME-config.html. This is the default name that the symbol framework will look for if the configuration template is not specified in the symbol definition. Like the presentation layer, the configuration layer is basic HTML. In the example below, we define two sections, Text Color and Background Color, and add a color picker custom control, `cs-color-picker`, under each section. `cs-color-picker` is an AngularJS [directive](https://docs.angularjs.org/guide/directive) to add the ability to use the PI Coresight color picker to a custom symbol. `cs-color-picker` has two custom attributes that are used to link it back to the underlying symbol, `property` and `config`. `property` points to a property on the passed in config object. `config` is the config object of the symbol.
 
     ```html
     <div class="c-side-pane t-toolbar">
         <span style="color:#fff; margin-left:15px">Text Color</span>
     </div>
-    <format-color-picker id="textColor" property="TextColor" config="config"></format-color-picker>
+    <div class="config-option-format">
+        <cs-color-picker id="textcolor" ng-model="config.TextColor"></cs-color-picker>
+    </div>
     <div class="c-side-pane t-toolbar">
         <span style="color:#fff; margin-left:15px">Background Color</span>
     </div>
-    <format-color-picker id="backgroundColor" property="BackgroundColor" config="config"></format-color-picker>
+    <div class="config-option-format">
+        <cs-color-picker id="backgroundcolor" ng-model="config.BackgroundColor"></cs-color-picker>
+    </div>
+
     ```
 
 1. Now by launching [PI Coresight][1], you will see you can right click on the symbol to configure it. When the configuration pane opens, the two color pickers defined in the config HTML are listed, but they have no effect on the symbol.
@@ -250,12 +255,15 @@ In this section, you will be creating a simple value symbol, much like the curre
     <div class="c-side-pane t-toolbar">
         <span style="color:#fff; margin-left:15px">Text Color</span>
     </div>
-    <format-color-picker id="textColor" property="TextColor" config="config"></format-color-picker>
+    <div class="config-option-format">
+        <cs-color-picker id="textcolor" ng-model="config.TextColor"></cs-color-picker>
+    </div>
     <div class="c-side-pane t-toolbar">
         <span style="color:#fff; margin-left:15px">Background Color</span>
     </div>
-    <format-color-picker id="backgroundColor" property="BackgroundColor" config="config"></format-color-picker>
-    
+    <div class="config-option-format">
+        <cs-color-picker id="backgroundcolor" ng-model="config.BackgroundColor"></cs-color-picker>
+    </div>
     <div class="c-side-pane t-toolbar">
         <span style="color:#fff; margin-left:15px">Show Options</span>
     </div>

--- a/tutorials/simplevalue/sym-simplevalue-config.html
+++ b/tutorials/simplevalue/sym-simplevalue-config.html
@@ -17,12 +17,15 @@
 <div class="c-side-pane t-toolbar">
     <span style="color:#fff; margin-left:15px">Text Color</span>
 </div>
-<format-color-picker id="textColor" property="TextColor" config="config"></format-color-picker>
+<div class="config-option-format">
+    <cs-color-picker id="textcolor" ng-model="config.TextColor"></cs-color-picker>
+</div>
 <div class="c-side-pane t-toolbar">
     <span style="color:#fff; margin-left:15px">Background Color</span>
 </div>
-<format-color-picker id="backgroundColor" property="BackgroundColor" config="config"></format-color-picker>
-
+<div class="config-option-format">
+    <cs-color-picker id="backgroundcolor" ng-model="config.BackgroundColor"></cs-color-picker>
+</div>
 <div class="c-side-pane t-toolbar">
     <span style="color:#fff; margin-left:15px">Show Options</span>
 </div>


### PR DESCRIPTION
Changed simple value's color picker from format-color-picker to cs-color-picker. PI Coresight 2016 R2 does not support format-color-picker anymore.